### PR TITLE
Fix panic for mongodb probe

### DIFF
--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -202,11 +202,11 @@ func addContainerProbe(statefulSet *apps.StatefulSet, mongodb *api.MongoDB) *app
 	for i, container := range statefulSet.Spec.Template.Spec.Containers {
 		if container.Name == api.ResourceSingularMongoDB {
 			readinessProbe := mongodb.Spec.PodTemplate.Spec.ReadinessProbe
-			if structs.IsZero(*readinessProbe) {
+			if readinessProbe == nil || structs.IsZero(*readinessProbe) {
 				readinessProbe = nil
 			}
 			livenessProbe := mongodb.Spec.PodTemplate.Spec.LivenessProbe
-			if structs.IsZero(*livenessProbe) {
+			if livenessProbe == nil || structs.IsZero(*livenessProbe) {
 				livenessProbe = nil
 			}
 			statefulSet.Spec.Template.Spec.Containers[i].LivenessProbe = livenessProbe

--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -202,11 +202,11 @@ func addContainerProbe(statefulSet *apps.StatefulSet, mongodb *api.MongoDB) *app
 	for i, container := range statefulSet.Spec.Template.Spec.Containers {
 		if container.Name == api.ResourceSingularMongoDB {
 			readinessProbe := mongodb.Spec.PodTemplate.Spec.ReadinessProbe
-			if readinessProbe == nil || structs.IsZero(*readinessProbe) {
+			if readinessProbe != nil && structs.IsZero(*readinessProbe) {
 				readinessProbe = nil
 			}
 			livenessProbe := mongodb.Spec.PodTemplate.Spec.LivenessProbe
-			if livenessProbe == nil || structs.IsZero(*livenessProbe) {
+			if livenessProbe != nil && structs.IsZero(*livenessProbe) {
 				livenessProbe = nil
 			}
 			statefulSet.Spec.Template.Spec.Containers[i].LivenessProbe = livenessProbe


### PR DESCRIPTION
While upgrade, mutating webhook may not hit. So, readiness and liveness probe will not have defaulted. So, handle nil as well. 