### PR TITLE
Initial RBAC support: create and use K8s service account for MongoDB …

### DIFF
--- a/pkg/controller/dormant_database.go
+++ b/pkg/controller/dormant_database.go
@@ -32,6 +32,19 @@ func (c *Controller) WaitUntilPaused(drmn *api.DormantDatabase) error {
 		return err
 	}
 
+	if err := c.waitUntilRBACStuffDeleted(db.ObjectMeta); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) waitUntilRBACStuffDeleted(meta metav1.ObjectMeta) error {
+	// Delete ServiceAccount
+	if err := core_util.WaitUntillServiceAccountDeleted(c.Client, meta); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controller/job.go
+++ b/pkg/controller/job.go
@@ -169,6 +169,11 @@ func (c *Controller) createRestoreJob(mongodb *api.MongoDB, snapshot *api.Snapsh
 		}
 		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, volume)
 	}
+
+	if c.EnableRBAC {
+		job.Spec.Template.Spec.ServiceAccountName = mongodb.OffshootName()
+	}
+
 	return c.Client.BatchV1().Jobs(mongodb.Namespace).Create(job)
 }
 

--- a/pkg/controller/mongodb.go
+++ b/pkg/controller/mongodb.go
@@ -60,6 +60,13 @@ func (c *Controller) create(mongodb *api.MongoDB) error {
 	}
 	c.GoverningService = governingService
 
+	if c.EnableRBAC {
+		// Ensure ClusterRoles for statefulsets
+		if err := c.ensureRBACStuff(mongodb); err != nil {
+			return err
+		}
+	}
+
 	// ensure database Service
 	vt1, err := c.ensureService(mongodb)
 	if err != nil {

--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -193,6 +193,10 @@ func (c *Controller) createStatefulSet(mongodb *api.MongoDB) (*apps.StatefulSet,
 		in.Spec.Template.Spec.Priority = mongodb.Spec.PodTemplate.Spec.Priority
 		in.Spec.Template.Spec.SecurityContext = mongodb.Spec.PodTemplate.Spec.SecurityContext
 
+		if c.EnableRBAC {
+			in.Spec.Template.Spec.ServiceAccountName = mongodb.OffshootName()
+		}
+
 		in.Spec.UpdateStrategy = mongodb.Spec.UpdateStrategy
 		return in
 	})


### PR DESCRIPTION
…cluster

MongoDB cluster runs with a dedicated service account instead of default.
Can be handy in case one wants to bind the service account
to a pod security policy (PSP) role binding.

Solves part of: https://github.com/kubedb/project/issues/390