### PR TITLE
Support for mongo 4.x

### DIFF
--- a/hack/dev/update-docker.sh
+++ b/hack/dev/update-docker.sh
@@ -64,6 +64,9 @@ done
 dbversions=(
   3.4
   3.6
+  4.0.5
+  4.0
+  4.1.7
 )
 
 exporters=(

--- a/hack/docker/mongo-tools/4.0.5/Dockerfile
+++ b/hack/docker/mongo-tools/4.0.5/Dockerfile
@@ -1,0 +1,13 @@
+FROM mongo:4.0.5
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    netcat \
+  && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /tmp/*
+
+COPY osm /usr/local/bin/osm
+COPY mongo-tools.sh /usr/local/bin/mongo-tools.sh
+
+ENTRYPOINT ["mongo-tools.sh"]

--- a/hack/docker/mongo-tools/4.0.5/make.sh
+++ b/hack/docker/mongo-tools/4.0.5/make.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eou pipefail
+
+GOPATH=$(go env GOPATH)
+REPO_ROOT=$GOPATH/src/github.com/kubedb/mongodb
+
+source "$REPO_ROOT/hack/libbuild/common/lib.sh"
+source "$REPO_ROOT/hack/libbuild/common/kubedb_image.sh"
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-kubedb}
+IMG=mongo-tools
+DB_VERSION=4.0.5
+TAG="$DB_VERSION" # suffix will be added in later versions
+OSM_VER=${OSM_VER:-0.9.1}
+
+DIST=$REPO_ROOT/dist
+mkdir -p $DIST
+
+build() {
+  pushd "$REPO_ROOT/hack/docker/mongo-tools/$DB_VERSION"
+
+  # Download osm
+  wget https://cdn.appscode.com/binaries/osm/${OSM_VER}/osm-alpine-amd64
+  chmod +x osm-alpine-amd64
+  mv osm-alpine-amd64 osm
+
+  local cmd="docker build --pull -t $DOCKER_REGISTRY/$IMG:$TAG ."
+  echo $cmd; $cmd
+
+  rm osm
+  popd
+}
+
+binary_repo $@

--- a/hack/docker/mongo-tools/4.0.5/mongo-tools.sh
+++ b/hack/docker/mongo-tools/4.0.5/mongo-tools.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -eou pipefail
+
+# ref: https://stackoverflow.com/a/7069755/244009
+# ref: https://jonalmeida.com/posts/2013/05/26/different-ways-to-implement-flags-in-bash/
+# ref: http://tldp.org/LDP/abs/html/comparison-ops.html
+
+show_help() {
+  echo "mongo-tools.sh - run tools"
+  echo " "
+  echo "mongo-tools.sh COMMAND [options]"
+  echo " "
+  echo "options:"
+  echo "-h, --help                         show brief help"
+  echo "    --data-dir=DIR                 path to directory holding db data (default: /var/data)"
+  echo "    --host=HOST                    database host"
+  echo "    --user=USERNAME                database username"
+  echo "    --bucket=BUCKET                name of bucket"
+  echo "    --folder=FOLDER                name of folder in bucket"
+  echo "    --snapshot=SNAPSHOT            name of snapshot"
+  echo "    --enable-analytics=ENABLE_ANALYTICS   send analytical events to Google Analytics (default true)"
+}
+
+RETVAL=0
+DEBUG=${DEBUG:-}
+DB_HOST=${DB_HOST:-}
+DB_PORT=${DB_PORT:-27017}
+DB_USER=${DB_USER:-}
+DB_PASSWORD=${DB_PASSWORD:-}
+DB_BUCKET=${DB_BUCKET:-}
+DB_FOLDER=${DB_FOLDER:-}
+DB_SNAPSHOT=${DB_SNAPSHOT:-}
+DB_DATA_DIR=${DB_DATA_DIR:-/var/data}
+OSM_CONFIG_FILE=/etc/osm/config
+ENABLE_ANALYTICS=${ENABLE_ANALYTICS:-true}
+
+op=$1
+shift
+
+while test $# -gt 0; do
+  case "$1" in
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --data-dir*)
+      export DB_DATA_DIR=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --host*)
+      export DB_HOST=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --user*)
+      export DB_USER=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --bucket*)
+      export DB_BUCKET=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --folder*)
+      export DB_FOLDER=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --snapshot*)
+      export DB_SNAPSHOT=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --analytics* | --enable-analytics*)
+      export ENABLE_ANALYTICS=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+if [ -n "$DEBUG" ]; then
+  env | sort | grep DB_*
+  echo ""
+fi
+
+# Wait for mongodb to start
+# ref: http://unix.stackexchange.com/a/5279
+while ! mongo --host "$DB_HOST" --port $DB_PORT --eval "db.adminCommand('ping')"; do
+  echo "Waiting... database is not ready yet"
+  sleep 5
+done
+
+# cleanup data dump dir
+mkdir -p "$DB_DATA_DIR"
+cd "$DB_DATA_DIR"
+rm -rf *
+
+case "$op" in
+  backup)
+    mongodump --host "$DB_HOST" --port $DB_PORT --username "$DB_USER" --password "$DB_PASSWORD" --out "$DB_DATA_DIR" "$@"
+    osm push --enable-analytics="$ENABLE_ANALYTICS" --osmconfig="$OSM_CONFIG_FILE" -c "$DB_BUCKET" "$DB_DATA_DIR" "$DB_FOLDER/$DB_SNAPSHOT"
+    ;;
+  restore)
+    osm pull --enable-analytics="$ENABLE_ANALYTICS" --osmconfig="$OSM_CONFIG_FILE" -c "$DB_BUCKET" "$DB_FOLDER/$DB_SNAPSHOT" "$DB_DATA_DIR"
+    mongorestore --host "$DB_HOST" --port $DB_PORT --username "$DB_USER" --password "$DB_PASSWORD" "$DB_DATA_DIR" "$@"
+    ;;
+  *)
+    (10)
+    echo $"Unknown op!"
+    RETVAL=1
+    ;;
+esac
+exit "$RETVAL"

--- a/hack/docker/mongo-tools/4.0/make.sh
+++ b/hack/docker/mongo-tools/4.0/make.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -xeou pipefail
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-kubedb}
+
+IMG=mongo-tools
+DB_VERSION=4.0
+PATCH=4.0.5
+
+TAG="$DB_VERSION" # suffix will be added later
+BASE_TAG="$PATCH" # suffix will be added later
+
+
+docker pull "$DOCKER_REGISTRY/$IMG:$BASE_TAG"
+
+docker tag "$DOCKER_REGISTRY/$IMG:$BASE_TAG" "$DOCKER_REGISTRY/$IMG:$TAG"
+docker push "$DOCKER_REGISTRY/$IMG:$TAG"

--- a/hack/docker/mongo-tools/4.1.7/Dockerfile
+++ b/hack/docker/mongo-tools/4.1.7/Dockerfile
@@ -1,0 +1,13 @@
+FROM mongo:4.1.7
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    netcat \
+  && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /tmp/*
+
+COPY osm /usr/local/bin/osm
+COPY mongo-tools.sh /usr/local/bin/mongo-tools.sh
+
+ENTRYPOINT ["mongo-tools.sh"]

--- a/hack/docker/mongo-tools/4.1.7/make.sh
+++ b/hack/docker/mongo-tools/4.1.7/make.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eou pipefail
+
+GOPATH=$(go env GOPATH)
+REPO_ROOT=$GOPATH/src/github.com/kubedb/mongodb
+
+source "$REPO_ROOT/hack/libbuild/common/lib.sh"
+source "$REPO_ROOT/hack/libbuild/common/kubedb_image.sh"
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-kubedb}
+IMG=mongo-tools
+DB_VERSION=4.1.7
+TAG="$DB_VERSION" # suffix will be added in later versions
+OSM_VER=${OSM_VER:-0.9.1}
+
+DIST=$REPO_ROOT/dist
+mkdir -p $DIST
+
+build() {
+  pushd "$REPO_ROOT/hack/docker/mongo-tools/$DB_VERSION"
+
+  # Download osm
+  wget https://cdn.appscode.com/binaries/osm/${OSM_VER}/osm-alpine-amd64
+  chmod +x osm-alpine-amd64
+  mv osm-alpine-amd64 osm
+
+  local cmd="docker build --pull -t $DOCKER_REGISTRY/$IMG:$TAG ."
+  echo $cmd; $cmd
+
+  rm osm
+  popd
+}
+
+binary_repo $@

--- a/hack/docker/mongo-tools/4.1.7/mongo-tools.sh
+++ b/hack/docker/mongo-tools/4.1.7/mongo-tools.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -eou pipefail
+
+# ref: https://stackoverflow.com/a/7069755/244009
+# ref: https://jonalmeida.com/posts/2013/05/26/different-ways-to-implement-flags-in-bash/
+# ref: http://tldp.org/LDP/abs/html/comparison-ops.html
+
+show_help() {
+  echo "mongo-tools.sh - run tools"
+  echo " "
+  echo "mongo-tools.sh COMMAND [options]"
+  echo " "
+  echo "options:"
+  echo "-h, --help                         show brief help"
+  echo "    --data-dir=DIR                 path to directory holding db data (default: /var/data)"
+  echo "    --host=HOST                    database host"
+  echo "    --user=USERNAME                database username"
+  echo "    --bucket=BUCKET                name of bucket"
+  echo "    --folder=FOLDER                name of folder in bucket"
+  echo "    --snapshot=SNAPSHOT            name of snapshot"
+  echo "    --enable-analytics=ENABLE_ANALYTICS   send analytical events to Google Analytics (default true)"
+}
+
+RETVAL=0
+DEBUG=${DEBUG:-}
+DB_HOST=${DB_HOST:-}
+DB_PORT=${DB_PORT:-27017}
+DB_USER=${DB_USER:-}
+DB_PASSWORD=${DB_PASSWORD:-}
+DB_BUCKET=${DB_BUCKET:-}
+DB_FOLDER=${DB_FOLDER:-}
+DB_SNAPSHOT=${DB_SNAPSHOT:-}
+DB_DATA_DIR=${DB_DATA_DIR:-/var/data}
+OSM_CONFIG_FILE=/etc/osm/config
+ENABLE_ANALYTICS=${ENABLE_ANALYTICS:-true}
+
+op=$1
+shift
+
+while test $# -gt 0; do
+  case "$1" in
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --data-dir*)
+      export DB_DATA_DIR=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --host*)
+      export DB_HOST=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --user*)
+      export DB_USER=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --bucket*)
+      export DB_BUCKET=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --folder*)
+      export DB_FOLDER=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --snapshot*)
+      export DB_SNAPSHOT=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --analytics* | --enable-analytics*)
+      export ENABLE_ANALYTICS=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+if [ -n "$DEBUG" ]; then
+  env | sort | grep DB_*
+  echo ""
+fi
+
+# Wait for mongodb to start
+# ref: http://unix.stackexchange.com/a/5279
+while ! mongo --host "$DB_HOST" --port $DB_PORT --eval "db.adminCommand('ping')"; do
+  echo "Waiting... database is not ready yet"
+  sleep 5
+done
+
+# cleanup data dump dir
+mkdir -p "$DB_DATA_DIR"
+cd "$DB_DATA_DIR"
+rm -rf *
+
+case "$op" in
+  backup)
+    mongodump --host "$DB_HOST" --port $DB_PORT --username "$DB_USER" --password "$DB_PASSWORD" --out "$DB_DATA_DIR" "$@"
+    osm push --enable-analytics="$ENABLE_ANALYTICS" --osmconfig="$OSM_CONFIG_FILE" -c "$DB_BUCKET" "$DB_DATA_DIR" "$DB_FOLDER/$DB_SNAPSHOT"
+    ;;
+  restore)
+    osm pull --enable-analytics="$ENABLE_ANALYTICS" --osmconfig="$OSM_CONFIG_FILE" -c "$DB_BUCKET" "$DB_FOLDER/$DB_SNAPSHOT" "$DB_DATA_DIR"
+    mongorestore --host "$DB_HOST" --port $DB_PORT --username "$DB_USER" --password "$DB_PASSWORD" "$DB_DATA_DIR" "$@"
+    ;;
+  *)
+    (10)
+    echo $"Unknown op!"
+    RETVAL=1
+    ;;
+esac
+exit "$RETVAL"

--- a/hack/docker/mongo/4.0.5/Dockerfile
+++ b/hack/docker/mongo/4.0.5/Dockerfile
@@ -1,0 +1,13 @@
+FROM mongo:4.0.5
+
+COPY on-start.sh /usr/local/bin/
+COPY peer-finder /usr/local/bin/
+
+RUN chmod -c 755 /usr/local/bin/peer-finder /usr/local/bin/on-start.sh
+
+# For starting mongodb container
+# default entrypoint of parent mongo:3.6
+# ENTRYPOINT ["docker-entrypoint.sh"]
+
+# For starting bootstraper init container (for mongodb replicaset)
+# ENTRYPOINT ["peer-finder"]

--- a/hack/docker/mongo/4.0.5/make.sh
+++ b/hack/docker/mongo/4.0.5/make.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eou pipefail
+
+GOPATH=$(go env GOPATH)
+REPO_ROOT=$GOPATH/src/github.com/kubedb/mongodb
+
+source "$REPO_ROOT/hack/libbuild/common/lib.sh"
+source "$REPO_ROOT/hack/libbuild/common/kubedb_image.sh"
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-kubedb}
+IMG=mongo
+DB_VERSION=4.0.5
+TAG="$DB_VERSION" # suffix will be added in later versions
+
+DIST=$REPO_ROOT/dist
+mkdir -p $DIST
+
+build() {
+  pushd "$REPO_ROOT/hack/docker/mongo/$DB_VERSION"
+
+  # Download Peer-finder
+  # ref: peer-finder: https://github.com/kubernetes/contrib/tree/master/peer-finder
+  # wget peer-finder: https://github.com/kubernetes/charts/blob/master/stable/mongodb-replicaset/install/Dockerfile#L18
+  wget -qO peer-finder https://github.com/kmodules/peer-finder/releases/download/v1.0.0/peer-finder
+  chmod +x peer-finder
+
+  local cmd="docker build --pull -t $DOCKER_REGISTRY/$IMG:$TAG ."
+  echo $cmd; $cmd
+
+  rm peer-finder
+  popd
+}
+
+binary_repo $@

--- a/hack/docker/mongo/4.0.5/on-start.sh
+++ b/hack/docker/mongo/4.0.5/on-start.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# ref: https://github.com/kubernetes/charts/blob/master/stable/mongodb-replicaset/init/on-start.sh
+
+replica_set="$REPLICA_SET"
+script_name=${0##*/}
+
+if [[ "$AUTH" == "true" ]]; then
+  admin_user="$MONGO_INITDB_ROOT_USERNAME"
+  admin_password="$MONGO_INITDB_ROOT_PASSWORD"
+  admin_creds=(-u "$admin_user" -p "$admin_password")
+  auth_args=(--auth --keyFile=/data/configdb/key.txt)
+fi
+
+function log() {
+  local msg="$1"
+  local timestamp
+  timestamp=$(date --iso-8601=ns)
+  echo "[$timestamp] [$script_name] $msg" >>/work-dir/log.txt
+}
+
+function shutdown_mongo() {
+  if [[ $# -eq 1 ]]; then
+    args="timeoutSecs: $1"
+  else
+    args='force: true'
+  fi
+  log "Shutting down MongoDB ($args)..."
+  mongo admin "${admin_creds[@]}" "${ssl_args[@]}" --eval "db.shutdownServer({$args})"
+}
+
+my_hostname=$(hostname)
+log "Bootstrapping MongoDB replica set member: $my_hostname"
+
+log "Reading standard input..."
+while read -ra line; do
+  if [[ "${line}" == *"${my_hostname}"* ]]; then
+    service_name="$line"
+    continue
+  fi
+  peers=("${peers[@]}" "$line")
+done
+
+# Generate the ca cert
+ca_crt=/data/configdb/tls.crt
+if [ -f "$ca_crt" ]; then
+  log "Generating certificate"
+  ca_key=/data/configdb/tls.key
+  pem=/work-dir/mongo.pem
+  ssl_args=(--ssl --sslCAFile "$ca_crt" --sslPEMKeyFile "$pem")
+
+  cat >openssl.cnf <<EOL
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = $(echo -n "$my_hostname" | sed s/-[0-9]*$//)
+DNS.2 = $my_hostname
+DNS.3 = $service_name
+DNS.4 = localhost
+DNS.5 = 127.0.0.1
+EOL
+
+  # Generate the certs
+  openssl genrsa -out mongo.key 2048
+  openssl req -new -key mongo.key -out mongo.csr -subj "/CN=$my_hostname" -config openssl.cnf
+  openssl x509 -req -in mongo.csr \
+    -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial \
+    -out mongo.crt -days 3650 -extensions v3_req -extfile openssl.cnf
+
+  rm mongo.csr
+  cat mongo.crt mongo.key >$pem
+  rm mongo.key mongo.crt
+fi
+
+log "Peers: ${peers[*]}"
+
+log "Starting a MongoDB instance..."
+mongod --config /data/configdb/mongod.conf --dbpath=/data/db --replSet="$replica_set" --port=27017 "${auth_args[@]}" --bind_ip=0.0.0.0 >>/work-dir/log.txt 2>&1 &
+
+log "Waiting for MongoDB to be ready..."
+until mongo "${ssl_args[@]}" --eval "db.adminCommand('ping')"; do
+  log "Retrying..."
+  sleep 2
+done
+
+log "Initialized."
+
+# try to find a master and add yourself to its replica set.
+for peer in "${peers[@]}"; do
+  if mongo admin --host "$peer" "${admin_creds[@]}" "${ssl_args[@]}" --eval "rs.isMaster()" | grep '"ismaster" : true'; then
+    log "Found master: $peer"
+    log "Adding myself ($service_name) to replica set..."
+    mongo admin --host "$peer" "${admin_creds[@]}" "${ssl_args[@]}" --eval "rs.add('$service_name')"
+
+    sleep 3
+
+    log 'Waiting for replica to reach SECONDARY state...'
+    until printf '.' && [[ $(mongo admin "${admin_creds[@]}" "${ssl_args[@]}" --quiet --eval "rs.status().myState") == '2' ]]; do
+      sleep 1
+    done
+
+    log '✓ Replica reached SECONDARY state.'
+
+    shutdown_mongo "60"
+    log "Good bye."
+    exit 0
+  fi
+done
+
+# else initiate a replica set with yourself.
+if mongo "${ssl_args[@]}" --eval "rs.status()" | grep "no replset config has been received"; then
+  log "Initiating a new replica set with myself ($service_name)..."
+  mongo "${ssl_args[@]}" --eval "rs.initiate({'_id': '$replica_set', 'members': [{'_id': 0, 'host': '$service_name'}]})"
+
+  sleep 3
+
+  log 'Waiting for replica to reach PRIMARY state...'
+  until printf '.' && [[ $(mongo "${ssl_args[@]}" --quiet --eval "rs.status().myState") == '1' ]]; do
+    sleep 1
+  done
+
+  log '✓ Replica reached PRIMARY state.'
+
+  if [[ "$AUTH" == "true" ]]; then
+    log "Creating admin user..."
+    mongo admin "${ssl_args[@]}" --eval "db.createUser({user: '$admin_user', pwd: '$admin_password', roles: [{role: 'root', db: 'admin'}]})"
+  fi
+
+  # Initialize Part for KubeDB. ref: https://github.com/docker-library/mongo/blob/a499e81e743b05a5237e2fd700c0284b17d3d416/3.4/docker-entrypoint.sh#L302
+  # Start
+  export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+  echo
+  ls -la /docker-entrypoint-initdb.d
+  for f in /docker-entrypoint-initdb.d/*; do
+    case "$f" in
+      *.sh)
+        echo "$0: running $f"
+        . "$f"
+        ;;
+      *.js)
+        echo "$0: running $f 1"
+        mongo "$MONGO_INITDB_DATABASE" "${admin_creds[@]}" "${ssl_args[@]}" --authenticationDatabase admin "$f"
+        ;;
+      *) echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
+  # END
+
+  log "Done."
+fi
+
+shutdown_mongo
+log "Good bye."

--- a/hack/docker/mongo/4.0/make.sh
+++ b/hack/docker/mongo/4.0/make.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -xeou pipefail
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-kubedb}
+IMG=mongo
+DB_VERSION=4.0
+TAG="$DB_VERSION"
+
+IMG=mongo
+DB_VERSION=4.0
+PATCH=4.0.5
+
+TAG="$DB_VERSION" # suffix will be added in later versions
+BASE_TAG="$PATCH" # suffix will be added in later versions
+
+
+docker pull "$DOCKER_REGISTRY/$IMG:$BASE_TAG"
+
+docker tag "$DOCKER_REGISTRY/$IMG:$BASE_TAG" "$DOCKER_REGISTRY/$IMG:$TAG"
+docker push "$DOCKER_REGISTRY/$IMG:$TAG"

--- a/hack/docker/mongo/4.1.7/Dockerfile
+++ b/hack/docker/mongo/4.1.7/Dockerfile
@@ -1,0 +1,13 @@
+FROM mongo:4.1.7
+
+COPY on-start.sh /usr/local/bin/
+COPY peer-finder /usr/local/bin/
+
+RUN chmod -c 755 /usr/local/bin/peer-finder /usr/local/bin/on-start.sh
+
+# For starting mongodb container
+# default entrypoint of parent mongo:3.6
+# ENTRYPOINT ["docker-entrypoint.sh"]
+
+# For starting bootstraper init container (for mongodb replicaset)
+# ENTRYPOINT ["peer-finder"]

--- a/hack/docker/mongo/4.1.7/make.sh
+++ b/hack/docker/mongo/4.1.7/make.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eou pipefail
+
+GOPATH=$(go env GOPATH)
+REPO_ROOT=$GOPATH/src/github.com/kubedb/mongodb
+
+source "$REPO_ROOT/hack/libbuild/common/lib.sh"
+source "$REPO_ROOT/hack/libbuild/common/kubedb_image.sh"
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-kubedb}
+IMG=mongo
+DB_VERSION=4.1.7 # suffix will be added in later versions
+TAG="$DB_VERSION"
+
+DIST=$REPO_ROOT/dist
+mkdir -p $DIST
+
+build() {
+  pushd "$REPO_ROOT/hack/docker/mongo/$DB_VERSION"
+
+  # Download Peer-finder
+  # ref: peer-finder: https://github.com/kubernetes/contrib/tree/master/peer-finder
+  # wget peer-finder: https://github.com/kubernetes/charts/blob/master/stable/mongodb-replicaset/install/Dockerfile#L18
+  wget -qO peer-finder https://github.com/kmodules/peer-finder/releases/download/v1.0.0/peer-finder
+  chmod +x peer-finder
+
+  local cmd="docker build --pull -t $DOCKER_REGISTRY/$IMG:$TAG ."
+  echo $cmd; $cmd
+
+  rm peer-finder
+  popd
+}
+
+binary_repo $@

--- a/hack/docker/mongo/4.1.7/on-start.sh
+++ b/hack/docker/mongo/4.1.7/on-start.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# ref: https://github.com/kubernetes/charts/blob/master/stable/mongodb-replicaset/init/on-start.sh
+
+replica_set="$REPLICA_SET"
+script_name=${0##*/}
+
+if [[ "$AUTH" == "true" ]]; then
+  admin_user="$MONGO_INITDB_ROOT_USERNAME"
+  admin_password="$MONGO_INITDB_ROOT_PASSWORD"
+  admin_creds=(-u "$admin_user" -p "$admin_password")
+  auth_args=(--auth --keyFile=/data/configdb/key.txt)
+fi
+
+function log() {
+  local msg="$1"
+  local timestamp
+  timestamp=$(date --iso-8601=ns)
+  echo "[$timestamp] [$script_name] $msg" >>/work-dir/log.txt
+}
+
+function shutdown_mongo() {
+  if [[ $# -eq 1 ]]; then
+    args="timeoutSecs: $1"
+  else
+    args='force: true'
+  fi
+  log "Shutting down MongoDB ($args)..."
+  mongo admin "${admin_creds[@]}" "${ssl_args[@]}" --eval "db.shutdownServer({$args})"
+}
+
+my_hostname=$(hostname)
+log "Bootstrapping MongoDB replica set member: $my_hostname"
+
+log "Reading standard input..."
+while read -ra line; do
+  if [[ "${line}" == *"${my_hostname}"* ]]; then
+    service_name="$line"
+    continue
+  fi
+  peers=("${peers[@]}" "$line")
+done
+
+# Generate the ca cert
+ca_crt=/data/configdb/tls.crt
+if [ -f "$ca_crt" ]; then
+  log "Generating certificate"
+  ca_key=/data/configdb/tls.key
+  pem=/work-dir/mongo.pem
+  ssl_args=(--ssl --sslCAFile "$ca_crt" --sslPEMKeyFile "$pem")
+
+  cat >openssl.cnf <<EOL
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = $(echo -n "$my_hostname" | sed s/-[0-9]*$//)
+DNS.2 = $my_hostname
+DNS.3 = $service_name
+DNS.4 = localhost
+DNS.5 = 127.0.0.1
+EOL
+
+  # Generate the certs
+  openssl genrsa -out mongo.key 2048
+  openssl req -new -key mongo.key -out mongo.csr -subj "/CN=$my_hostname" -config openssl.cnf
+  openssl x509 -req -in mongo.csr \
+    -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial \
+    -out mongo.crt -days 3650 -extensions v3_req -extfile openssl.cnf
+
+  rm mongo.csr
+  cat mongo.crt mongo.key >$pem
+  rm mongo.key mongo.crt
+fi
+
+log "Peers: ${peers[*]}"
+
+log "Starting a MongoDB instance..."
+mongod --config /data/configdb/mongod.conf --dbpath=/data/db --replSet="$replica_set" --port=27017 "${auth_args[@]}" --bind_ip=0.0.0.0 >>/work-dir/log.txt 2>&1 &
+
+log "Waiting for MongoDB to be ready..."
+until mongo "${ssl_args[@]}" --eval "db.adminCommand('ping')"; do
+  log "Retrying..."
+  sleep 2
+done
+
+log "Initialized."
+
+# try to find a master and add yourself to its replica set.
+for peer in "${peers[@]}"; do
+  if mongo admin --host "$peer" "${admin_creds[@]}" "${ssl_args[@]}" --eval "rs.isMaster()" | grep '"ismaster" : true'; then
+    log "Found master: $peer"
+    log "Adding myself ($service_name) to replica set..."
+    mongo admin --host "$peer" "${admin_creds[@]}" "${ssl_args[@]}" --eval "rs.add('$service_name')"
+
+    sleep 3
+
+    log 'Waiting for replica to reach SECONDARY state...'
+    until printf '.' && [[ $(mongo admin "${admin_creds[@]}" "${ssl_args[@]}" --quiet --eval "rs.status().myState") == '2' ]]; do
+      sleep 1
+    done
+
+    log '✓ Replica reached SECONDARY state.'
+
+    shutdown_mongo "60"
+    log "Good bye."
+    exit 0
+  fi
+done
+
+# else initiate a replica set with yourself.
+if mongo "${ssl_args[@]}" --eval "rs.status()" | grep "no replset config has been received"; then
+  log "Initiating a new replica set with myself ($service_name)..."
+  mongo "${ssl_args[@]}" --eval "rs.initiate({'_id': '$replica_set', 'members': [{'_id': 0, 'host': '$service_name'}]})"
+
+  sleep 3
+
+  log 'Waiting for replica to reach PRIMARY state...'
+  until printf '.' && [[ $(mongo "${ssl_args[@]}" --quiet --eval "rs.status().myState") == '1' ]]; do
+    sleep 1
+  done
+
+  log '✓ Replica reached PRIMARY state.'
+
+  if [[ "$AUTH" == "true" ]]; then
+    log "Creating admin user..."
+    mongo admin "${ssl_args[@]}" --eval "db.createUser({user: '$admin_user', pwd: '$admin_password', roles: [{role: 'root', db: 'admin'}]})"
+  fi
+
+  # Initialize Part for KubeDB. ref: https://github.com/docker-library/mongo/blob/a499e81e743b05a5237e2fd700c0284b17d3d416/3.4/docker-entrypoint.sh#L302
+  # Start
+  export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+  echo
+  ls -la /docker-entrypoint-initdb.d
+  for f in /docker-entrypoint-initdb.d/*; do
+    case "$f" in
+      *.sh)
+        echo "$0: running $f"
+        . "$f"
+        ;;
+      *.js)
+        echo "$0: running $f 1"
+        mongo "$MONGO_INITDB_DATABASE" "${admin_creds[@]}" "${ssl_args[@]}" --authenticationDatabase admin "$f"
+        ;;
+      *) echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
+  # END
+
+  log "Done."
+fi
+
+shutdown_mongo
+log "Good bye."

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	authorization "github.com/kubedb/apimachinery/apis/authorization/v1alpha1"
 	"github.com/appscode/go/encoding/json/types"
 	"github.com/appscode/go/log"
 	reg_util "github.com/appscode/kutil/admissionregistration/v1beta1"
@@ -10,6 +9,7 @@ import (
 	"github.com/appscode/kutil/tools/queue"
 	pcm "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/kubedb/apimachinery/apis"
+	authorization "github.com/kubedb/apimachinery/apis/authorization/v1alpha1"
 	catlog "github.com/kubedb/apimachinery/apis/catalog/v1alpha1"
 	api "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
 	cs "github.com/kubedb/apimachinery/client/clientset/versioned"

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -13,9 +13,9 @@ import (
 var (
 	DockerRegistry     = "kubedbci"
 	SelfHostedOperator = false
-	DBCatalogName      = "3.6-v2"
-	DBVersion          = "3.6-v2"
-	DBToolsTag         = "3.6-v2"
+	DBCatalogName      = "4.0"
+	DBVersion          = "4.0"
+	DBToolsTag         = "4.0"
 	ExporterTag        = "v1.0.0"
 )
 

--- a/test/e2e/framework/mongodb.go
+++ b/test/e2e/framework/mongodb.go
@@ -101,7 +101,7 @@ func (f *Framework) EventuallyMongoDB(meta metav1.ObjectMeta) GomegaAsyncAsserti
 			}
 			return true
 		},
-		time.Minute*13,
+		time.Minute*10,
 		time.Second*5,
 	)
 }
@@ -113,7 +113,7 @@ func (f *Framework) EventuallyMongoDBRunning(meta metav1.ObjectMeta) GomegaAsync
 			Expect(err).NotTo(HaveOccurred())
 			return mongodb.Status.Phase == api.DatabasePhaseRunning
 		},
-		time.Minute*15,
+		time.Minute*10,
 		time.Second*5,
 	)
 }

--- a/test/e2e/framework/snapshot.go
+++ b/test/e2e/framework/snapshot.go
@@ -97,7 +97,7 @@ func (f *Framework) EventuallySnapshotCount(meta metav1.ObjectMeta) GomegaAsyncA
 
 			return len(snapshotList.Items)
 		},
-		time.Minute*15,
+		time.Minute*10,
 		time.Second*5,
 	)
 }
@@ -121,7 +121,7 @@ func (f *Framework) EventuallyMultipleSnapshotFinishedProcessing(meta metav1.Obj
 			}
 			return nil
 		},
-		time.Minute*15,
+		time.Minute*10,
 		time.Second*5,
 	)
 }


### PR DESCRIPTION
The license states

`The only substantive modification is section 13, which makes clear the condition to offering MongoDB as a service. A company that offers a publicly available MongoDB as a service must open source the software it uses to offer such service, including the management software, user interfaces, application program interfaces, automation software, monitoring software, backup software, storage software and hosting software, all such that a user could run an instance of the service using the source code made available.`

ref: https://www.mongodb.com/licensing/server-side-public-license/faq#difference

As, all the tools we use in kubedb are open sourced, we can add support of new releases of mongodb (including 4.x).

Fixes https://github.com/kubedb/project/issues/407
xref: https://github.com/kubedb/project/issues/359


Add `4.1` later once it is stable. https://hub.docker.com/_/mongo