### PR TITLE
set resource requirements for bootstrap init container

### DIFF
--- a/pkg/controller/replicaset.go
+++ b/pkg/controller/replicaset.go
@@ -95,6 +95,7 @@ func (c *Controller) upsertRSInitContainer(statefulSet *apps.StatefulSet, mongod
 				MountPath: dataDirectoryPath,
 			},
 		},
+		Resources: mongodb.Spec.PodTemplate.Spec.Resources,
 	}
 
 	initContainers := statefulSet.Spec.Template.Spec.InitContainers


### PR DESCRIPTION
The resource requirements for the bootstrap init container are not set. If you configure default resource requirements, for example using the LimitRange Admission Controller, it could be that the container never returns.