### PR TITLE
Don't set annotation to AppBinding

### DIFF
--- a/pkg/controller/appbinding.go
+++ b/pkg/controller/appbinding.go
@@ -61,7 +61,6 @@ func (c *Controller) ensureAppBinding(db *api.MongoDB) (kutil.VerbType, error) {
 	_, vt, err := appcat_util.CreateOrPatchAppBinding(c.AppCatalogClient, meta, func(in *appcat.AppBinding) *appcat.AppBinding {
 		core_util.EnsureOwnerReference(&in.ObjectMeta, ref)
 		in.Labels = db.OffshootLabels()
-		in.Annotations = db.Spec.ServiceTemplate.Annotations
 
 		in.Spec.Type = appmeta.Type()
 		in.Spec.Version = mongodbVersion.Spec.Version


### PR DESCRIPTION
Why?
- Annotation is used for auto backup in Stash. If we set annotation in AppBinding from KubeDB then the auto backup annotation will get lost if any update happen to database crd.