### PR TITLE
Fix create database secret will end with dead loop

### DIFF
--- a/pkg/controller/secret.go
+++ b/pkg/controller/secret.go
@@ -75,7 +75,7 @@ func (c *Controller) createDatabaseSecret(mongodb *api.MongoDB) (*core.SecretVol
 		randPassword := ""
 
 		// if the password starts with "-" it will cause error in bash scripts (in mongodb-tools)
-		for randPassword = rand.GeneratePassword(); randPassword[0] == '-'; {
+		for randPassword = rand.GeneratePassword(); randPassword[0] == '-'; randPassword = rand.GeneratePassword() {
 		}
 
 		secret := &core.Secret{


### PR DESCRIPTION
```go
// if the password starts with "-" it will cause error in bash scripts (in mongodb-tools)
		for randPassword = rand.GeneratePassword(); randPassword[0] == '-'; {
		}
```

will end with dead loop if  ```randPassword = rand.GeneratePassword();``` get a string start with "-"


Change As
```go
// if the password starts with "-" it will cause error in bash scripts (in mongodb-tools)
		for randPassword = rand.GeneratePassword(); randPassword[0] == '-'; randPassword = rand.GeneratePassword(){
		}
```