### PR TITLE
Wipeout if custom databaseSecret has been deleted

### DIFF
--- a/pkg/controller/dormant_database.go
+++ b/pkg/controller/dormant_database.go
@@ -97,6 +97,11 @@ func (c *Controller) wipeOutDatabase(meta metav1.ObjectMeta, secrets []string, r
 	//Dont delete unused secrets that are not owned by kubeDB
 	for _, unusedSecret := range unusedSecrets.List() {
 		secret, err := c.Client.CoreV1().Secrets(meta.Namespace).Get(unusedSecret, metav1.GetOptions{})
+		//Maybe user has delete this secret
+		if kerr.IsNotFound(err) {
+			unusedSecrets.Delete(secret.Name)
+			continue
+		}
 		if err != nil {
 			return errors.Wrap(err, "error in getting db secret")
 		}


### PR DESCRIPTION
[Can not wipeout a MongoDB with custom databaseSecret, if custom databaseSecret has been deleted #703](https://github.com/kubedb/project/issues/703)