### PR TITLE
Prepare for release v0.7.0-beta.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	kmodules.xyz/objectstore-api v0.0.0-20200521103120-92080446e04d
 	kmodules.xyz/offshoot-api v0.0.0-20200521035628-e135bf07b226
 	kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0
-	kubedb.dev/apimachinery v0.14.0-beta.2.0.20200918070437-ec58309af775
+	kubedb.dev/apimachinery v0.14.0-beta.3
 	stash.appscode.dev/apimachinery v0.11.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1521,8 +1521,8 @@ kmodules.xyz/prober v0.0.0-20200521101241-adf06150535c h1:aV6O9NbDpnFVra/D8c7b7T
 kmodules.xyz/prober v0.0.0-20200521101241-adf06150535c/go.mod h1:XYWZkfQquD09Mn+O7piHS+SEPq9oFV1Wy2WZ9DA+oeA=
 kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0 h1:rEOWPdiRYShJdJxX0sf76JYWOMzPQH4v8ByT+DRCmVY=
 kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0/go.mod h1:9hUftUcjvzDSiO5LIbe2U8Naz4tyS9Ndf1LRzsytMzs=
-kubedb.dev/apimachinery v0.14.0-beta.2.0.20200918070437-ec58309af775 h1:81t7rXE4YNvBwvtNnklXy+otyw8t/oNFjkLSU3/32y8=
-kubedb.dev/apimachinery v0.14.0-beta.2.0.20200918070437-ec58309af775/go.mod h1:EyPX0GZpOXJKUbhRxyW+HP2ydUPut86RmwPExJdhzr0=
+kubedb.dev/apimachinery v0.14.0-beta.3 h1:ju+Ljf5DC3Bojg3zv2NeFtwIKEvIBCJkkbGIJ4khoDU=
+kubedb.dev/apimachinery v0.14.0-beta.3/go.mod h1:EyPX0GZpOXJKUbhRxyW+HP2ydUPut86RmwPExJdhzr0=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1202,7 +1202,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.14.0-beta.2.0.20200918070437-ec58309af775
+# kubedb.dev/apimachinery v0.14.0-beta.3
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.09.21-beta.3
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/6
Signed-off-by: 1gtm <1gtm@appscode.com>