### PR TITLE
Fix annotations passing to AppBinding

### DIFF
--- a/pkg/controller/appbinding.go
+++ b/pkg/controller/appbinding.go
@@ -112,7 +112,7 @@ func (c *Controller) ensureAppBinding(db *api.MongoDB) (kutil.VerbType, error) {
 		func(in *appcat.AppBinding) *appcat.AppBinding {
 			core_util.EnsureOwnerReference(&in.ObjectMeta, owner)
 			in.Labels = db.OffshootLabels()
-			in.Annotations = meta_util.FilterKeys(kubedb.GroupName, in.Annotations, db.Annotations)
+			in.Annotations = meta_util.FilterKeys(kubedb.GroupName, nil, db.Annotations)
 
 			in.Spec.Type = appmeta.Type()
 			in.Spec.Version = mongodbVersion.Spec.Version


### PR DESCRIPTION
Signed-off-by: Emruz Hossain <emruz@appscode.com>

**Why?**
- We should always overwrite AppBinding's annotations with database CR's annotations instead of upserting. Otherwise, if we remove any annotation from the database CR, the old annotations will still exist in the AppBinding.