### PR TITLE
Prepare for release v0.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20201105074044-be7a1044891a
 	kmodules.xyz/offshoot-api v0.0.0-20210308072215-581e7685cd02
 	kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
-	kubedb.dev/apimachinery v0.17.2-0.20210415110305-fdf2681b7c53
+	kubedb.dev/apimachinery v0.18.0
 	stash.appscode.dev/apimachinery v0.12.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1430,8 +1430,8 @@ kmodules.xyz/prober v0.0.0-20210218144026-43e923722d81 h1:mi0XHhavbXQqj9q89dNhWa
 kmodules.xyz/prober v0.0.0-20210218144026-43e923722d81/go.mod h1:2eN8X5Wq7/AAgE5AWMAX8T0lE51HZiYEldG2RQuouX4=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6 h1:9+EIwxUrXrM8QD9rC1Fg+6CQK0vPniFO3ClaKih010M=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6/go.mod h1:xLgewoOzwR5ZrVOHQ2SR0P4E7tgCyBWbYlUawEXgeF4=
-kubedb.dev/apimachinery v0.17.2-0.20210415110305-fdf2681b7c53 h1:qInWcSGHqgjUsI/phQAR97T5WgoLL4BqsaI5waa1JVk=
-kubedb.dev/apimachinery v0.17.2-0.20210415110305-fdf2681b7c53/go.mod h1:Z40oGFQbjQJoa7WzhJrOJDgEOian5YzQJdol0bFs1Sg=
+kubedb.dev/apimachinery v0.18.0 h1:Ar4qup7opGzzKENZeidgi6fQHmLqhTsVkbok+TJxDOo=
+kubedb.dev/apimachinery v0.18.0/go.mod h1:Z40oGFQbjQJoa7WzhJrOJDgEOian5YzQJdol0bFs1Sg=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1128,7 +1128,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.17.2-0.20210415110305-fdf2681b7c53
+# kubedb.dev/apimachinery v0.18.0
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.04.16
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/37
Signed-off-by: 1gtm <1gtm@appscode.com>