### PR TITLE
Prepare for release v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20210618110729-9cd872c66513
 	kmodules.xyz/offshoot-api v0.0.0-20210618005544-5217a24765da
 	kmodules.xyz/webhook-runtime v0.0.0-20210618013329-0accb929102b
-	kubedb.dev/apimachinery v0.19.0-rc.0
+	kubedb.dev/apimachinery v0.19.0
 	stash.appscode.dev/apimachinery v0.14.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1281,8 +1281,8 @@ kmodules.xyz/resource-metadata v0.5.7 h1:5xjq5pEp5hZK+jdkY/4wGk/FMtTyvQ9LlErh7lQ
 kmodules.xyz/resource-metadata v0.5.7/go.mod h1:Jdi7zBXRwwFTOR0CxwKxqJhsDVIilhrgNipPjnKLyrs=
 kmodules.xyz/webhook-runtime v0.0.0-20210618013329-0accb929102b h1:aUZw6p8qeZN23DdjpzvseY/oXYwhXCzgvFjIc9ufuQc=
 kmodules.xyz/webhook-runtime v0.0.0-20210618013329-0accb929102b/go.mod h1:MFZFmJk9IXNHwq8JlF/mukwBDbopFQj4swaB2MWHc/U=
-kubedb.dev/apimachinery v0.19.0-rc.0 h1:Nd8Us1RQ8Vr4jgwJc4tCy7YTz0GGafN1Hy2PfYb3n0s=
-kubedb.dev/apimachinery v0.19.0-rc.0/go.mod h1:EsDnTm5D9VBJiZjBfx9JMDgOldvtKcRP7Y52AFzsMTg=
+kubedb.dev/apimachinery v0.19.0 h1:sK3d5qAK/CCheYtKmlvtXxjTPqxlZBY75cVaI5fXIvE=
+kubedb.dev/apimachinery v0.19.0/go.mod h1:EsDnTm5D9VBJiZjBfx9JMDgOldvtKcRP7Y52AFzsMTg=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1291,7 +1291,7 @@ kmodules.xyz/resource-metadata/pkg/graph
 ## explicit
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.19.0-rc.0
+# kubedb.dev/apimachinery v0.19.0
 ## explicit
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.06.23
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/39
Signed-off-by: 1gtm <1gtm@appscode.com>